### PR TITLE
Make name of id parameter configurable

### DIFF
--- a/config.go
+++ b/config.go
@@ -45,6 +45,7 @@ func init() {
 }
 
 func setDefaults() {
+	viper.SetDefault("rid_param","id")
 	viper.SetDefault("log_level", "info")
 	viper.SetDefault("slack.bot_username", "PhishBot")
 	viper.SetDefault("slack.bot_emoji", ":blowfish:")

--- a/messages.go
+++ b/messages.go
@@ -71,7 +71,7 @@ func NewEventDetails(detailsRaw []byte) (EventDetails, error) {
 }
 
 func (e EventDetails) ID() string {
-	return e.Payload.Get("id")
+	return e.Payload.Get(viper.GetString("rid_param"))
 }
 
 func (e EventDetails) UserAgent() string {


### PR DESCRIPTION
This allows you to configure the name of the result id parameter contained in the webhook messages. Closes #4 

You might want to do that, if you run a custom gophish version set not to use the name `rid`.

@t94j0 I haven't tested this with the vanilla gophish version, shouldn't be much of an issue though. 